### PR TITLE
Pinning nova-docker to a specific commit on a different repo

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -93,8 +93,8 @@ FileUtils.mkdir(host_cache_path) unless File.exist?(host_cache_path)
 
 DEVSTACK_BRANCH       = ENV['DEVSTACK_BRANCH']       ||= "master"
 DEVSTACK_REPO         = ENV['DEVSTACK_REPO']         ||= "https://github.com/openstack-dev/devstack.git"
-NOVADOCKER_BRANCH     = ENV['NOVADOCKER_BRANCH']     ||= "master"
-NOVADOCKER_REPO       = ENV['NOVADOCKER_REPO']       ||= "https://github.com/stackforge/nova-docker.git"
+NOVADOCKER_BRANCH     = ENV['NOVADOCKER_BRANCH']     ||= "reconciling-changes"
+NOVADOCKER_REPO       = ENV['NOVADOCKER_REPO']       ||= "https://github.com/devdattakulkarni/nova-docker.git"
 SOLUM_BRANCH          = ENV['SOLUM_BRANCH']          ||= "master"
 SOLUM_REPO            = ENV['SOLUM_REPO']            ||= "https://github.com/stackforge/solum.git"
 SOLUMCLIENT_BRANCH    = ENV['SOLUMCLIENT_BRANCH']    ||= "master"


### PR DESCRIPTION
Upstream nova-docker is failing in Solum's vagrant run.
I have submitted a patch which fixes some of the issues.

https://review.openstack.org/#/c/207588/3

This will unblock Solum vagrant environment till that patch is merged